### PR TITLE
Recreating/reloading the options no longer plays the animation

### DIFF
--- a/plugins/stingray/the_debuginator_plugin/c_api_the_debuginator.cpp
+++ b/plugins/stingray/the_debuginator_plugin/c_api_the_debuginator.cpp
@@ -237,7 +237,7 @@ TheDebuginator* create_debuginator(const char* id, DebuginatorPluginCreateContex
 		uisize_item->leaf.default_index = 1;
 		uisize_item->leaf.hot_index = 1;
 		uisize_item->leaf.active_index = 1;
-		debuginator_activate(debuginator, uisize_item);
+		debuginator_activate(debuginator, uisize_item, false);
 	}
 
 	plugin_memory->num_debuginators++;

--- a/plugins/stingray/the_debuginator_plugin/c_api_the_debuginator.h
+++ b/plugins/stingray/the_debuginator_plugin/c_api_the_debuginator.h
@@ -65,7 +65,7 @@ extern "C" {
 		void(*set_default_value)(TheDebuginator* debuginator, const char* path, const char* value_title, int value_index); // value index is used if value_title == NULL
 		void(*set_edit_type)(TheDebuginator* debuginator, const char* path, DebuginatorItemEditorDataType edit_type);
 
-		void(*activate)(TheDebuginator* debuginator, DebuginatorItem* item);
+		void(*activate)(TheDebuginator* debuginator, DebuginatorItem* item, bool animate);
 		void(*move_to_next_leaf)(TheDebuginator* debuginator, bool long_move);
 		void(*move_to_prev_leaf)(TheDebuginator* debuginator, bool long_move);
 		void(*move_to_child)(TheDebuginator* debuginator, bool toggle_and_activate);


### PR DESCRIPTION
Playing all animations on reload confused people. Added a flag that lets you control whether to play an animation when activating, so we can set default values without animating it.