### PR TITLE
Fixed two bugs related to filtering and distance calculation.

### DIFF
--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -239,6 +239,7 @@ typedef struct DebuginatorFolderData {
 typedef struct DebuginatorLeafData {
 	// A helpful text for the user
 	const char* description;
+	int description_line_count;
 
 	// The values and the UI titles
 	const char** value_titles;
@@ -1090,6 +1091,18 @@ DebuginatorItem* debuginator_create_array_item(TheDebuginator* debuginator,
 	item->leaf.description = description == NULL ? "" : description;
 	debuginator__adjust_num_visible_children(item->parent, 1);
 
+	if (description && !item->is_folder) {
+		const char* description = item->leaf.description;
+		float description_width = debuginator->size.x - 50;
+		int description_height = 0;
+		unsigned row_lengths[32];
+		unsigned row_count = 0;
+		debuginator->word_wrap(description, debuginator->theme.fonts[DEBUGINATOR_ItemDescription], description_width, &row_count, row_lengths, 32, debuginator->app_user_data);
+		item->leaf.description_line_count = row_count;
+	} else if (!item->is_folder) {
+		item->leaf.description_line_count = 0;
+	}
+
 	//TODO preserve hot item
 	return item;
 }
@@ -1261,7 +1274,7 @@ void debuginator_remove_item(TheDebuginator* debuginator, DebuginatorItem* item)
 
 	debuginator__set_total_height(item->parent, item->parent->total_height - item->total_height);
 
-	if (!item->is_folder) {
+	if (!item->is_folder && !item->is_filtered) {
 		// If it's a folder we've already adjusted the parent's count when we removed the item's children above.
 		debuginator__adjust_num_visible_children(item->parent, -1);
 	}
@@ -1287,14 +1300,14 @@ void debuginator_remove_item_by_path(TheDebuginator* debuginator, const char* pa
 
 bool debuginator__distance_to_hot_item(DebuginatorItem* item, DebuginatorItem* hot_item, int item_height, int* distance) {
 	if (item == hot_item) {
-		if (!item->is_folder && item->leaf.is_expanded) {
+		if (!item->is_folder && item->leaf.is_expanded && !item->is_filtered) {
 			*distance += item_height * (item->leaf.hot_index + 1);
 		}
 		return true;
 	}
 
 	*distance += item_height;
-	if (item->is_folder) {
+	if (item->is_folder && !item->is_filtered) {
 		DebuginatorItem* child = debuginator__first_visible_child(item);
 		while (child) {
 			bool found = debuginator__distance_to_hot_item(child, hot_item, item_height, distance);
@@ -1304,9 +1317,36 @@ bool debuginator__distance_to_hot_item(DebuginatorItem* item, DebuginatorItem* h
 
 			child = debuginator__next_visible_sibling(child);
 		}
+	} else if (item->leaf.is_expanded && !item->is_filtered) {
+		*distance += item_height * item->leaf.num_values;
+		*distance += item->leaf.description_line_count * item_height;
+	}
+	return false;
+}
+
+int debuginator_total_height(TheDebuginator* debuginator) {
+	int height = 0;
+	DebuginatorItem *last_item = debuginator__first_visible_child(debuginator->root);
+	while (last_item && (last_item->next_sibling || last_item->is_folder)) {
+		if (last_item->next_sibling) {
+			last_item = debuginator__next_visible_sibling(last_item);
+		} else {
+			if (last_item->folder.num_visible_children == 0) {
+				break;
+			} else {
+				last_item = debuginator__first_visible_child(last_item);
+			}
+		}
+	}
+	debuginator__distance_to_hot_item(debuginator->root, last_item, debuginator->item_height, &height);
+
+	if (last_item && !last_item->is_folder && last_item->leaf.is_expanded) {
+		for (int i = 0; i < last_item->leaf.num_values; ++i) {
+			height += debuginator->item_height;
+		}
 	}
 
-	return false;
+	return height;
 }
 
 bool debuginator_is_filtering_enabled(TheDebuginator* debuginator) {

--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -1092,12 +1092,11 @@ DebuginatorItem* debuginator_create_array_item(TheDebuginator* debuginator,
 	debuginator__adjust_num_visible_children(item->parent, 1);
 
 	if (description && !item->is_folder) {
-		const char* description = item->leaf.description;
 		float description_width = debuginator->size.x - 50;
 		int description_height = 0;
 		unsigned row_lengths[32];
 		unsigned row_count = 0;
-		debuginator->word_wrap(description, debuginator->theme.fonts[DEBUGINATOR_ItemDescription], description_width, &row_count, row_lengths, 32, debuginator->app_user_data);
+		debuginator->word_wrap(item->leaf.description, debuginator->theme.fonts[DEBUGINATOR_ItemDescription], description_width, &row_count, row_lengths, 32, debuginator->app_user_data);
 		item->leaf.description_line_count = row_count;
 	} else if (!item->is_folder) {
 		item->leaf.description_line_count = 0;
@@ -1325,28 +1324,7 @@ bool debuginator__distance_to_hot_item(DebuginatorItem* item, DebuginatorItem* h
 }
 
 int debuginator_total_height(TheDebuginator* debuginator) {
-	int height = 0;
-	DebuginatorItem *last_item = debuginator__first_visible_child(debuginator->root);
-	while (last_item && (last_item->next_sibling || last_item->is_folder)) {
-		if (last_item->next_sibling) {
-			last_item = debuginator__next_visible_sibling(last_item);
-		} else {
-			if (last_item->folder.num_visible_children == 0) {
-				break;
-			} else {
-				last_item = debuginator__first_visible_child(last_item);
-			}
-		}
-	}
-	debuginator__distance_to_hot_item(debuginator->root, last_item, debuginator->item_height, &height);
-
-	if (last_item && !last_item->is_folder && last_item->leaf.is_expanded) {
-		for (int i = 0; i < last_item->leaf.num_values; ++i) {
-			height += debuginator->item_height;
-		}
-	}
-
-	return height;
+	return debuginator->root->total_height;
 }
 
 bool debuginator_is_filtering_enabled(TheDebuginator* debuginator) {


### PR DESCRIPTION
When filtering items with multiline descriptions the height would
be calculated with a hardcoded line count of 1.

If an item was filtered, its height was still counted for distance
to the active item.