### PR TITLE
Changed control scheme & activated gamepad in the stingray plugin.

### DIFF
--- a/plugins/stingray/the_debuginator_plugin/c_api_the_debuginator.h
+++ b/plugins/stingray/the_debuginator_plugin/c_api_the_debuginator.h
@@ -73,7 +73,7 @@ extern "C" {
 
 		bool(*is_filtering_enabled)(TheDebuginator* debuginator);
 		void(*set_filtering_enabled)(TheDebuginator* debuginator, bool enabled);
-		char*(*get_filter)(TheDebuginator* debuginator);
+		const char*(*get_filter)(TheDebuginator* debuginator);
 		void(*update_filter)(TheDebuginator* debuginator, const char* wanted_filter);
 
 		void(*set_item_height)(TheDebuginator* debuginator, int item_height);


### PR DESCRIPTION
Does *NOT* include an updated help description for the new scheme.

# New scheme
## Keyboard
Home+End added to go to first and last item in the entire list.
Left goes to parent item and closes folders.
Escape and delete now close the debuginator.
Enter toggles/expands items.
Filtering is automatically opened when something is typed, and closed when
a zero-length filter is backspaced (so backspace with no filter closes it).
Ctrl+W clears filter.

## Gamepad
Option opens & closes the debuginator
Left stick behaves like d-pad (with repeat after a short wait).
A (xbox) / X (PS) toggles/expands items
B (xbox) / Circle (PS) moves to parent/closes folders
Sshoulder buttons jump between leaves (for faster navigation)

## Other notes:
Filtering now refocuses on the best matching item.