### PR TITLE
Fix block allocator free-past-block.

### DIFF
--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -657,7 +657,7 @@ static void debuginator__block_allocator_init(DebuginatorBlockAllocator* allocat
 
 static void* debuginator__block_allocate(DebuginatorBlockAllocator* allocator, int num_bytes) {
 	(void)num_bytes;
-	if (allocator->data->block_capacity - allocator->current_block_size < num_bytes) {
+	if (allocator->data->block_capacity - allocator->current_block_size < allocator->element_size) {
 		if (allocator->data->arena_end <= allocator->data->next_free_block) {
 			return NULL;
 		}


### PR DESCRIPTION
The block allocator checked if there was enough room for num_bytes
(allocation size), while on free the allocator marks memory of the span
of the full element size, leading to a write past the end of the block
if the last element was smaller than the full size. Since each block
begins with a pointer to the allocator that owns it, this leads to a
dereference of 0xcd-repeating on any following free from the next block.