### PR TITLE
Collapse recursive

### DIFF
--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -2403,7 +2403,11 @@ void debuginator_update_filter(TheDebuginator* debuginator, const char* wanted_f
 					next = next->next;
 				}
 
-				if (sorted_item->next == NULL && debuginator->best_sorted_item != NULL) {
+
+				if (sorted_item->prev == NULL) {
+					// We're the first item
+					debuginator->best_sorted_item = sorted_item;
+				} else if (sorted_item->next == NULL && debuginator->best_sorted_item != NULL) {
 					// We're the last item (worst scoring of the ones found so far)
 					next = debuginator->best_sorted_item;
 					while (next->next) {
@@ -2411,11 +2415,6 @@ void debuginator_update_filter(TheDebuginator* debuginator, const char* wanted_f
 					}
 					next->next = sorted_item;
 					sorted_item->prev = next;
-				}
-
-				if (sorted_item->prev == NULL) {
-					// We're the first item
-					debuginator->best_sorted_item = sorted_item;
 				}
 			}
 		}

--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -3570,6 +3570,27 @@ void debuginator_set_collapsed(TheDebuginator* debuginator, DebuginatorItem* ite
 	}
 }
 
+void debuginator__collapse_recursive(TheDebuginator* debuginator, DebuginatorItem *item, int collapse_depth, int depth) {
+	if (!item->is_folder)
+		return;
+
+	DebuginatorItem* child = debuginator__first_visible_child(item);
+	while (child != NULL) {
+		debuginator__collapse_recursive(debuginator, child, collapse_depth, depth + 1);
+		child = debuginator__next_visible_sibling(child);
+	}
+
+	if (depth >= collapse_depth) {
+		debuginator_set_collapsed(debuginator, item, true);
+	}
+}
+
+void debuginator_collapse_to_depth(TheDebuginator* debuginator, int depth) {
+	DebuginatorItem *item = debuginator->root;
+	
+	debuginator__collapse_recursive(debuginator, item, depth, 0);
+}
+
 void debuginator_move_sibling_previous(TheDebuginator* debuginator) {
 	DebuginatorItem* hot_item = debuginator->hot_item;
 

--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -3482,7 +3482,6 @@ void debuginator_activate(TheDebuginator* debuginator, DebuginatorItem* item, bo
 	if (item->leaf.num_values <= 0) {
 		// "Action" items doesn't have a list of values, they just get triggered
 		if (item->leaf.on_item_changed_callback != NULL) {
-			void* value = item->leaf.num_values == DEBUGINATOR_CUSTOM_VALUE_STATE_COUNT ? item->leaf.values : NULL;
 			item->leaf.on_item_changed_callback(item, item->leaf.values, NULL, debuginator->app_user_data);
 		}
 		return;

--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -2034,6 +2034,11 @@ void debuginator_remove_item(TheDebuginator* debuginator, DebuginatorItem* item)
 	if (debuginator->hot_item == item) {
 		debuginator->hot_item = debuginator__nearest_visible_item(item);
 	}
+	
+	// Only update the height of the parent if we were visible
+	if (item->parent->is_folder && !item->parent->folder.is_collapsed) {
+		debuginator__set_total_height(item->parent, item->parent->total_height - item->total_height);
+	}
 
 	debuginator__set_total_height(item->parent, item->parent->total_height - item->total_height);
 

--- a/the_debuginator.h
+++ b/the_debuginator.h
@@ -1594,6 +1594,7 @@ DebuginatorItem* debuginator_new_folder_item(TheDebuginator* debuginator, Debugi
 		folder_item->folder.is_collapsed = true;
 	}
 	debuginator__deallocate(debuginator, item_setting);
+	debuginator__deallocate(debuginator, full_path);
 
 	return folder_item;
 }
@@ -1611,6 +1612,7 @@ DebuginatorItem* debuginator_create_folder_item(TheDebuginator* debuginator, Deb
 		folder_item->folder.is_collapsed = true;
 	}
 	debuginator__deallocate(debuginator, item_setting);
+	debuginator__deallocate(debuginator, full_path);
 
 	return folder_item;
 }
@@ -1788,6 +1790,8 @@ DebuginatorItem* debuginator_create_array_item(TheDebuginator* debuginator,
 			debuginator_assign_hot_key(debuginator, hot_key_key, full_path, DEBUGINATOR_NO_HOT_INDEX, NULL);
 		}
 	}
+
+	debuginator__deallocate(debuginator, full_path);
 
 	return item;
 }


### PR DESCRIPTION
This was added to our version because it was hard to keep track of the amount of options we have and navigate it with a controller; this allows us to collapse to "root's children" when we open the menu unless specifically disabled by the user, and have them "discover" the submenues as the recurse down the tree.

Couldn't figure out how to make the other commits go away :( 